### PR TITLE
copy object optimization: async on AWS iff owners are same

### DIFF
--- a/src/main/scala/s3/client.scala
+++ b/src/main/scala/s3/client.scala
@@ -137,33 +137,39 @@ class Bucket(val name: String, val client: AmazonS3) {
   }
 
   /**
-   * Copy object
+   * Copy an object from one bucket to this bucket.
+   *
+   * If the buckets are on the same AWS account, the copy will occur
+   * as an asynchonous computation on the AWS backend. Otherwise, the
+   * data will be copied to this JVM and then sent back to AWS to be
+   * put into the bucket.
    */
   def copyObject(key: String, other: Bucket): Future[Unit] = Future {
     time(s"S3Bucket.copyObject[$key]") {
 
-      def logError(t: Throwable) = {
-
-        logger.error(s"Failed to copy $key from bucket $name to bucket ${other.name}", t)
-      }
-
-      logger.info(s"Attempting to copy $key to bucket ${other.name}")
-
       Try {
+        if (client.getS3AccountOwner.getId == other.client.getS3AccountOwner.getId) {
+          // same AWS account, can do backend async copy
+          client.copyObject(name, key, other.name, key)
 
-        for (is <- managed(client.getObject(name, key).getObjectContent())) {
-
-          other.client.putObject(other.name, key, is, new ObjectMetadata())
+        } else {
+          // different AWS accounts, must stream the data into this JVM and then send
+          // it off to be copied
+          for (is <- managed(client.getObject(name, key).getObjectContent)) {
+            other.client.putObject(other.name, key, is, new ObjectMetadata())
+          }
         }
-
       } match {
 
         // Nothing to do - it's a file copy, so a pure side effect
         case Success(_) =>
+          logger.info(s"Copied $key to bucket ${other.name}")
+
         // Handle non-fatal errors
-        case Failure(NonFatal(t)) =>
-          logger error (s"Failed to copy $key from bucket $name to bucket ${other.name}", t)
+        case Failure(NonFatal(err)) =>
+          logger.error(s"Failed to copy $key from bucket $name to bucket ${other.name}", err)
       }
+      () // Future[Unit]
     }
   }
 

--- a/src/main/scala/s3/client.scala
+++ b/src/main/scala/s3/client.scala
@@ -27,6 +27,8 @@ import scala.util.{ Failure, Success, Try }
  */
 class Bucket(val name: String, val client: AmazonS3) {
 
+  import Bucket.logger
+
   /**
    * Default batch size when iterating S3 keys
    */
@@ -185,6 +187,9 @@ class Bucket(val name: String, val client: AmazonS3) {
 object Bucket {
 
   def apply(name: String, client: AmazonS3) = new Bucket(name, client)
+
+  private lazy val logger = Log.getLogger[Bucket.type]
+
 }
 
 class S3Client(val underlying: AmazonS3) {


### PR DESCRIPTION
If, when calling copyObject(key,other bucket) on a Bucket instnace, the client's account owner IDs are the same, then we will kick off a copy job on the AWS backend asynchronously. This will not incurr any network costs on our side.

Otherwise, we will resort to copying the object contents directly to this JVM and then send the contents back to AWS.

Also added a single private logger to the Bucket object that the Bucket class uses. Fixes some existing compile errors on master!